### PR TITLE
Add description to metric

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -55,7 +55,7 @@ Show which notes are enabled by ID. The value 1 means is enabled. If metric labe
 ### Label
 
 - `note_id`: this indicate the note id of SAP note.
-
+- `note_desc`: provide description about the note enabled.
 ## Meta
 
 The meta collector collects all "meta" metrics/information about saptune. (version etc.)

--- a/notes_collector.go
+++ b/notes_collector.go
@@ -25,9 +25,9 @@ func getNoteDesc(enabledNoteID string) string {
 	for _, noteID := range tuningOptions.GetSortedIDs() {
 		noteObj := tuningOptions[noteID]
 		if noteID == enabledNoteID {
-			// this is how looks like noteObj.Name, remove the version of the not
+			// this is how looks like noteObj.Name, remove the version.
 			// "Linux: User and system resource limits \n			Version 5 from 18.06.2018 ",
-			solDescRaw := strings.Split(noteObj.Name(), "/n")
+			solDescRaw := strings.Split(noteObj.Name(), "\n")
 			// return only description
 			return solDescRaw[0]
 		}

--- a/notes_collector.go
+++ b/notes_collector.go
@@ -71,7 +71,7 @@ func (c *NoteCollector) noteEnabled(ch chan<- prometheus.Metric) {
 	for _, note := range notes {
 		noteDesc := getNoteDesc(note)
 		if noteDesc == "" {
-			log.Warnf("Could not find the note descriptino for given note ID %s", note)
+			log.Warnf("Could not find the note description for given note ID %s", note)
 		}
 		ch <- c.MakeGaugeMetric("enabled", float64(1), note, noteDesc)
 	}

--- a/test/note.metrics
+++ b/test/note.metrics
@@ -1,9 +1,9 @@
 # HELP saptune_note_enabled This metrics show with 1 all the enabled notes on the system
 # TYPE saptune_note_enabled gauge
-saptune_note_enabled{note_id="1771258"} 1
-saptune_note_enabled{note_id="1980196"} 1
-saptune_note_enabled{note_id="2382421"} 1
-saptune_note_enabled{note_id="2534844"} 1
-saptune_note_enabled{note_id="2578899"} 1
-saptune_note_enabled{note_id="2684254"} 1
-saptune_note_enabled{note_id="941735"} 1
+saptune_note_enabled{note_desc="",note_id="1771258"} 1
+saptune_note_enabled{note_desc="",note_id="1980196"} 1
+saptune_note_enabled{note_desc="",note_id="2382421"} 1
+saptune_note_enabled{note_desc="",note_id="2534844"} 1
+saptune_note_enabled{note_desc="",note_id="2578899"} 1
+saptune_note_enabled{note_desc="",note_id="2684254"} 1
+saptune_note_enabled{note_desc="",note_id="941735"} 1


### PR DESCRIPTION
# description:

this add metric like :

```
# HELP saptune_note_enabled This metrics show with 1 all the enabled notes on the system
# TYPE saptune_note_enabled gauge
saptune_note_enabled{note_desc="Indexserver Crash During Startup due to Insufficient Shared Memory Segment",note_id="2534844"} 1
saptune_note_enabled{note_desc="Linux: User and system resource limits",note_id="1771258"} 1
saptune_note_enabled{note_desc="Optimizing the Network Configuration on HANA- and OS-Level",note_id="2382421"} 1
saptune_note_enabled{note_desc="SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP Applications 15",note_id="2684254"} 1
saptune_note_enabled{note_desc="SAP memory management system for 64-bit Linux systems",note_id="941735"} 1
saptune_note_enabled{note_desc="SUSE LINUX Enterprise Server 15: Installation notes",note_id="2578899"} 1
saptune_note_enabled{note_desc="Setting Linux Kernel Parameter /proc/sys/vm/max_map_count on SAP HANA Systems",note_id="1980196"} 1

```